### PR TITLE
Use HTTPS in example URLs for security best practices

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -20,7 +20,7 @@ bar and supports configuration files.`,
   gogetit download https://example.com/file1.zip https://example.com/file2.zip
 
   # Scrape website metadata
-  gogetit scrape http://example.com`,
+  gogetit scrape https://example.com`,
 }
 
 func Execute() error {


### PR DESCRIPTION
## Description
This PR addresses issue #8 by updating the example URL in the root command help text from HTTP to HTTPS.

## Changes Made
- Changed `http://example.com` to `https://example.com` in the root command example

## Benefits
- Promotes secure connection practices in documentation
- Follows OWASP security best practices
- Sets a good example for users learning to use the tool

## Testing
- The change is a simple string update in documentation/help text
- No functional code changes required

Fixes #8