### PR TITLE
fix(utils): check file.Close error in WriteFile (#6)

### DIFF
--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -76,8 +76,15 @@ func WriteFile(path string, data []byte) error {
 		return err
 	}
 
-	_, err = file.Write(data)
-	file.Close()
+	_, writeErr := file.Write(data)
+	closeErr := file.Close()
 
-	return err
+	// Surface the write error first when both fail — it's the
+	// actionable cause. A close error after a successful write still
+	// matters: buffered data may not have flushed and the file on
+	// disk would be silently truncated.
+	if writeErr != nil {
+		return writeErr
+	}
+	return closeErr
 }

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -79,7 +79,7 @@ func WriteFile(path string, data []byte) error {
 	_, writeErr := file.Write(data)
 	closeErr := file.Close()
 
-	// Surface the write error first when both fail — it's the
+	// Surface the write error first when both fail, it's the
 	// actionable cause. A close error after a successful write still
 	// matters: buffered data may not have flushed and the file on
 	// disk would be silently truncated.

--- a/pkg/utils/file_test.go
+++ b/pkg/utils/file_test.go
@@ -215,3 +215,32 @@ func TestSanitizePath(t *testing.T) {
 		})
 	}
 }
+
+func TestWriteFile_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "subdir", "out.bin")
+	want := []byte("hello, world\n")
+
+	if err := WriteFile(path, want); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("file contents: got %q, want %q", got, want)
+	}
+}
+
+func TestWriteFile_NoSilentClose(t *testing.T) {
+	// Sanity check: WriteFile must not blackhole both write and close
+	// errors. The success case is exercised by TestWriteFile_RoundTrip;
+	// here we just confirm that returning a write error from a bad path
+	// still propagates (CreateFile fails, we never reach Close).
+	err := WriteFile("/nonexistent\x00bad/path/file.bin", []byte("x"))
+	if err == nil {
+		t.Fatal("expected error for bad path, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #6. ``WriteFile`` ignored ``file.Close()``, so a Close error on a successfully-written buffer (the case the issue calls out, buffered writes that haven't flushed) silently produced a truncated file with no error returned.

## Change

```go
_, writeErr := file.Write(data)
closeErr := file.Close()

if writeErr != nil {
    return writeErr
}
return closeErr
```

Surface the write error first when both fail (it's the actionable cause), otherwise propagate the close error. ``defer`` was an option but doesn't capture the close return, explicit ordering reads cleaner here for two errors.

## Test plan

- [x] ``go build ./...``, clean
- [x] ``go test -run TestWriteFile ./pkg/utils/``, both new tests pass
- [x] New ``TestWriteFile_RoundTrip``, writes, reads back, asserts content matches (covers the happy path)
- [x] New ``TestWriteFile_NoSilentClose``, confirms the bad-path error still propagates from ``CreateFile``
- Note: the unrelated ``TestPathTraversalProtection/traversal_within_nested_dirs`` was already failing on ``main`` before this change (a real bug in ``SanitizePath`` per the test's own assertion message); not in scope here